### PR TITLE
FIX - Se corrigió el uso erróneo del comando revert en Git Hub

### DIFF
--- a/src/Consolidado.cpp
+++ b/src/Consolidado.cpp
@@ -1,4 +1,3 @@
-
 #include "Consolidado.h"
 #include <iostream>
 #include <string>
@@ -77,5 +76,3 @@ void Consolidado::setParametros(const map<string,string> &parametros) {
     }
 
 }
-
-

--- a/src/Consolidado.h
+++ b/src/Consolidado.h
@@ -19,7 +19,7 @@ private:
     int matriculadosPrimerSemestre = 0;
     int graduados = 0;
 
-    bool verificarMapaValido(const map<string, string> &) ;
+    static bool verificarMapaValido(const map<string, string> &);
 public:
     Consolidado() = default;
     Consolidado(int idSexo, string sexo, int ano, int semestre);

--- a/src/GestorTxt.cpp
+++ b/src/GestorTxt.cpp
@@ -1,0 +1,45 @@
+//
+// Created by User on 14/10/2024.
+//
+
+#include "GestorTxt.h"
+
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+
+using std::string;
+using std::map;
+using std::vector;
+
+void GestorTxt::exportarDatos(const string& filePath, const vector<map<string, string>>& datos) {
+    try {
+        std::ofstream file(filePath);
+        if (!file.is_open()) {
+            throw std::ios_base::failure("No se pudo abrir el archivo TXT para exportar: " + filePath);
+        }
+
+        for (auto entryIter = datos.begin(); entryIter != datos.end(); ++entryIter) {
+            const auto& entry = *entryIter;
+            for (auto pairIter = entry.begin(); pairIter != entry.end(); ++pairIter) {
+                const auto& key = pairIter->first;
+                const auto& value = pairIter->second;
+                file << key << ": " << value << "\n";
+            }
+            file << "--------------------------\n"; // Separador de entradas
+        }
+
+
+        file.close();
+        cout << "Exportación a TXT exitosa: " << filePath << endl;
+    }
+    catch (const std::ios_base::failure& e) {
+        std::cerr << "Error de archivo: " << e.what() << endl;
+    }
+    catch (const std::exception& e) {
+        std::cerr << "Error inesperado: " << e.what() << std::endl;
+    }
+    catch (...) {
+        std::cerr << "Ocurrió un error desconocido durante la exportación a TXT." << std::endl;
+    }
+}

--- a/src/ProgramaAcademico.cpp
+++ b/src/ProgramaAcademico.cpp
@@ -1,4 +1,3 @@
-
 #include "ProgramaAcademico.h"
 #include "Consolidado.h"
 #include <iostream>
@@ -108,8 +107,3 @@ void ProgramaAcademico::mostrarIdentificadoresPrograma() {
     cout << "Código SNIES: " << this->getDato("codigosnies") << endl;
     cout << "Nombre del programa académico: " << this->getDato("programaacademico") << endl;
 }
-
-
-
-
-


### PR DESCRIPTION
Este pull request incluye varios cambios en las clases `Consolidado`, `GestorTxt` y `ProgramaAcademico`, centrándose en agregar nueva funcionalidad, mejorar la estructura del código y limpiar líneas innecesarias.

### Nueva funcionalidad:
* [`src/GestorTxt.cpp`](diffhunk://#diff-b16c0570a90efac5d0efa75c0015e786500e052c78bc4f69848d827d2e1c0188R1-R45): Se añadió un nuevo método `exportarDatos` para exportar datos a un archivo TXT con manejo de errores para operaciones de archivo.

### Mejoras en la estructura del código:
* [`src/Consolidado.h`](diffhunk://#diff-f74a59c635130ec24a6afc0dd087a4e6bb725293e266973562bf9c6ba3282f87L22-R22): Se cambió el método `verificarMapaValido` para que sea un método estático.

### Limpieza de código:
* [`src/Consolidado.cpp`](diffhunk://#diff-e4cb4a9f6cd9cac2810247109c05beac3cd5b325a4933bce18c04dccf802106fL80-L81): Se eliminaron líneas en blanco innecesarias.
* [`src/Consolidado.cpp`](diffhunk://#diff-e4cb4a9f6cd9cac2810247109c05beac3cd5b325a4933bce18c04dccf802106fL1): Se eliminó una línea en blanco innecesaria al inicio del archivo.
* [`src/ProgramaAcademico.cpp`](diffhunk://#diff-a3da25c73eb9f7ff3e3a94cdfc2c83874a2d6f40ee02a92ba1d80c73f605923fL111-L115): Se eliminaron líneas en blanco innecesarias. [[1]](diffhunk://#diff-a3da25c73eb9f7ff3e3a94cdfc2c83874a2d6f40ee02a92ba1d80c73f605923fL111-L115) [[2]](diffhunk://#diff-a3da25c73eb9f7ff3e3a94cdfc2c83874a2d6f40ee02a92ba1d80c73f605923fL1)